### PR TITLE
Deploy script for local machine

### DIFF
--- a/deployLocal.sh
+++ b/deployLocal.sh
@@ -1,0 +1,12 @@
+# Starts redis server on port 6379 with localhost
+# Start redis-server as a background process (daemon)
+brew services start redis
+
+# Maven lifecycle
+mvn clean
+mvn package
+
+# Launch server 
+java -jar target/dbot-1.0-SNAPSHOT.jar
+
+


### PR DESCRIPTION
- Adds a script for deploying discord bot locally
- Note: This requires the user to have already registered a bot, and made a .env with their bot token in it.